### PR TITLE
Fixes in UTG generation

### DIFF
--- a/droidbot/app_event.py
+++ b/droidbot/app_event.py
@@ -1507,7 +1507,6 @@ class UtgDynamicFactory(StateBasedEventFactory):
         super(UtgDynamicFactory, self).__init__(device, app)
         self.explored_views = set()
         self.state_transitions = set()
-        self.unexplored_states = {}
 
         self.last_event_flag = ""
         self.last_touched_view_str = None

--- a/droidbot/state_transition_graph.py
+++ b/droidbot/state_transition_graph.py
@@ -51,7 +51,7 @@ class TransitionGraph(object):
         self.state_files = ["start"]
         self.state_json = [{}]
         for root, _, states in os.walk(self.state_path):
-            for state in states:
+            for state in sorted(states):
                 if state[-4:] == "json":
                     if self.state_offset > 0:
                         self.state_offset -= 1

--- a/droidbot/state_transition_graph.py
+++ b/droidbot/state_transition_graph.py
@@ -48,8 +48,8 @@ class TransitionGraph(object):
             self.events = self.events[-self.state_offset:]
 
         # read device state data
-        self.state_files = ["start"]
-        self.state_json = [{}]
+        self.state_files = ["start", "homescreen"]
+        self.state_json = [{}, {}]
         for root, _, states in os.walk(self.state_path):
             for state in sorted(states):
                 if state[-4:] == "json":


### PR DESCRIPTION
States in UTG were mixed because of not using sorting. Besides they were shifted because the second state (after KeyEvent "Home") was not considered.
One more slight change: removed an unused variable in UtgDynamicFactory.