### PR TITLE
Fixes in processing viewclient structures and profiling events on old Android versions

### DIFF
--- a/droidbot/app.py
+++ b/droidbot/app.py
@@ -96,7 +96,7 @@ class App(object):
             package_name += "/%s" % self.get_main_activity()
         return Intent(suffix=package_name)
 
-    def get_start_with_profiling_intent(self, trace_file):
+    def get_start_with_profiling_intent(self, trace_file, sampling=None):
         """
         get an intent to start the app with profiling
         :return: Intent
@@ -104,7 +104,10 @@ class App(object):
         package_name = self.get_package_name()
         if self.get_main_activity():
             package_name += "/%s" % self.get_main_activity()
-        return Intent(prefix="start --start-profiler %s --sampling 1000" % trace_file, suffix=package_name)
+        if sampling is not None:
+            return Intent(prefix="start --start-profiler %s --sampling %d" % (trace_file, sampling), suffix=package_name)
+        else:
+            return Intent(prefix="start --start-profiler %s" % trace_file, suffix=package_name)
 
     def get_stop_intent(self):
         """

--- a/droidbot/app_event.py
+++ b/droidbot/app_event.py
@@ -1591,7 +1591,8 @@ class UtgDynamicFactory(StateBasedEventFactory):
 
         # first try to find a preferable view
         for view in views:
-            view_text = view['text'].lower().strip()
+            view_text = view['text'] if view['text'] is not None else ''
+            view_text = view_text.lower().strip()
             if view_text in self.preferred_buttons and \
                             (state.foreground_activity, view['view_str']) not in self.explored_views:
                 self.device.logger.info("selected an un-clicked view: %s" % view['view_str'])

--- a/droidbot/app_event.py
+++ b/droidbot/app_event.py
@@ -248,6 +248,10 @@ class EventLog(object):
         self.trace_remote_file = "/data/local/tmp/event.trace"
         self.is_profiling = False
         self.profiling_pid = -1
+        self.sampling = None
+        if self.device.get_sdk_version() >= 21: #sampling feature was added in Android 5.0 (API level 21)
+            self.sampling = 1000
+
 
     def to_dict(self):
         return {
@@ -285,11 +289,14 @@ class EventLog(object):
         pid = self.device.get_app_pid(self.app)
         if pid is None:
             if self.is_start_event():
-                start_intent = self.app.get_start_with_profiling_intent(self.trace_remote_file)
+                start_intent = self.app.get_start_with_profiling_intent(self.trace_remote_file, self.sampling)
                 self.event.intent = start_intent.get_cmd()
                 self.is_profiling = True
             return
-        self.device.get_adb().shell(["am", "profile", "start", "--sampling", "1000", str(pid), self.trace_remote_file])
+        if self.sampling is not None:
+            self.device.get_adb().shell(["am", "profile", "start", "--sampling", self.sampling, str(pid), self.trace_remote_file])
+        else:
+            self.device.get_adb().shell(["am", "profile", "start", str(pid), self.trace_remote_file])
         self.is_profiling = True
         self.profiling_pid = pid
 
@@ -304,6 +311,9 @@ class EventLog(object):
                 self.profiling_pid = pid
 
             self.device.get_adb().shell(["am", "profile", "stop", str(self.profiling_pid)])
+            if self.sampling is None:
+                time.sleep(3) #guess this time can vary between machines
+
             if output_dir is None:
                 output_dir = os.path.join(self.device.output_dir, "events")
             if not os.path.exists(output_dir):

--- a/droidbot/device.py
+++ b/droidbot/device.py
@@ -749,11 +749,11 @@ class DeviceState(object):
         for view in view_client_views:
             if isinstance(view, View):
                 view_dict = {}
-                view_dict['class'] = view.getClass()
-                view_dict['text'] = view.getText()
-                view_dict['resource_id'] = view.getId()
+                view_dict['class'] = view.getClass() #None is possible value
+                view_dict['text'] = view.getText() #None is possible value
+                view_dict['resource_id'] = view.getId() #None is possible value
                 view_dict['temp_id'] = view2id_map.get(view)
-                view_dict['parent'] = view2id_map.get(view.getParent())
+                view_dict['parent'] = view2id_map.get(view.getParent()) #None is possible value
                 view_dict['children'] = [view2id_map.get(view_child) for view_child in view.getChildren()]
                 view_dict['enabled'] = view.isEnabled()
                 view_dict['focused'] = view.isFocused()


### PR DESCRIPTION
I've faced the same problem with processing viewclient structures (that they can return None in unexpected places).

Another problem was in saving profiler info on old Android versions (specifically Android 4.1.2 which is the only one working with droidbox). There is no --sampling key in am commands until Android 5.0 and we should use command without it otherwise the profiler does not start. Without sampling profiler traces get quite large and so we face another problem with obtaining them after 'am profile stop'. This command seems to be asyncronous and if we pull the profiler trace file from device immediately after 'am profile stop' we get it empty. I did not find a proper solution for this and put a sleep for 3 seconds here which is enough at least on my machine.