### PR TITLE
add full method trace for Android version >= 5.0

### DIFF
--- a/droidbot/droidbot.py
+++ b/droidbot/droidbot.py
@@ -25,7 +25,7 @@ class DroidBot(object):
                  env_policy=None, event_policy=None, with_droidbox=False,
                  event_count=None, event_interval=None, event_duration=None,
                  quiet=False,
-                 use_hierarchy_viewer=False, enable_method_profiling=False):
+                 use_hierarchy_viewer=False, profiling_method=None):
         """
         initiate droidbot with configurations
         :return:
@@ -63,7 +63,7 @@ class DroidBot(object):
             self.env_manager = AppEnvManager(self.device, self.app, env_policy)
             self.event_manager = AppEventManager(self.device, self.app, event_policy,
                                                  event_count, event_interval, event_duration,
-                                                 enable_method_profiling=enable_method_profiling)
+                                                 profiling_method=profiling_method)
         except Exception as e:
             import traceback
             traceback.print_exc()

--- a/droidbot/start.py
+++ b/droidbot/start.py
@@ -50,8 +50,8 @@ def parse_args():
                         help="run in quiet mode (dump warning messages only).")
     parser.add_argument("-use_hierarchy_viewer", action="store_true", dest="use_hierarchy_viewer",
                         help="force use Hierarchy Viewer to dump UI states instead of UI Automator.")
-    parser.add_argument("-enable_method_profiling", action="store_true", dest="enable_method_profiling",
-                        help="enable method profiling to get the method trace of each event.")
+    parser.add_argument("-enable_method_profiling", action="store", dest="profiling_method",
+                        help="enable method profiling to get the method trace of each event. can be \"full\" or sampling rate.")
     options = parser.parse_args()
     # print options
     return options
@@ -79,7 +79,7 @@ def main():
                         event_count=opts.event_count,
                         quiet=opts.quiet,
                         use_hierarchy_viewer=opts.use_hierarchy_viewer,
-                        enable_method_profiling=opts.enable_method_profiling)
+                        profiling_method=opts.profiling_method)
     droidbot.start()
     return
 


### PR DESCRIPTION
This PR is to enable full method trace option (not sampling) on high Android versions (>=5.0).
Now the `-enable_method_profiling` option can be either
1. An integer indicating the sampling rate;
2. "full", indicating full method trace;
3. Not given, indicating method trace is disabled.