### PR TITLE
add no view shuffle option for bfs and dfs policy

### DIFF
--- a/droidbot/droidbot.py
+++ b/droidbot/droidbot.py
@@ -22,7 +22,7 @@ class DroidBot(object):
     instance = None
 
     def __init__(self, app_path, device_serial, output_dir=None,
-                 env_policy=None, event_policy=None, script_path=None,
+                 env_policy=None, event_policy=None, no_shuffle=False, script_path=None,
                  event_count=None, event_interval=None, event_duration=None,
                  quiet=False, with_droidbox=False,
                  use_hierarchy_viewer=False, profiling_method=None):
@@ -61,7 +61,7 @@ class DroidBot(object):
                 self.droidbox = DroidBox(droidbot=self, output_dir=self.output_dir)
 
             self.env_manager = AppEnvManager(self.device, self.app, env_policy)
-            self.event_manager = AppEventManager(self.device, self.app, event_policy,
+            self.event_manager = AppEventManager(self.device, self.app, event_policy, no_shuffle,
                                                  event_count, event_interval, event_duration,
                                                  script_path=script_path,
                                                  profiling_method=profiling_method)

--- a/droidbot/start.py
+++ b/droidbot/start.py
@@ -32,9 +32,7 @@ def parse_args():
                              # '%s\tsend events based on static analysis result; \n'
                              # '%s\tbased on dynamic app state, this policy requires framework instrumented\n'
                              '\"%s\"\tExplore the UI using a breadth-first strategy.\n'
-                             '\"%s\"\tExplore the UI using a breadth-first strategy, but without view shuffling\n'
                              '\"%s\"\tExplore the UI using a depth-first strategy.\n'
-                             '\"%s\"\tExplore the UI using a depth-first strategy, but without view shuffling\n'
                              # '<%s>\tUse a script to customize input for certain states.\n'
                              # '%s\tmanually interact with your app, and we will record the events.\n'
                              %
@@ -45,12 +43,12 @@ def parse_args():
                                  # app_event.POLICY_STATIC,
                                  # app_event.POLICY_DYNAMIC,
                                  app_event.POLICY_BFS,
-                                 app_event.POLICY_BFS_NO_SHUFFLE,
                                  app_event.POLICY_DFS,
-                                 app_event.POLICY_DFS_NO_SHUFFLE,
                                  # app_event.POLICY_FILE,
                                  # app_event.POLICY_MANUAL
                              ))
+    parser.add_argument("-no_shuffle", action="store_true", dest="no_shuffle",
+                        help="Explore the UI without view shuffling")
     parser.add_argument("-script", action="store", dest="script_path",
                         help="Use a script to customize input for certain states.")
     parser.add_argument("-count", action="store", dest="event_count",
@@ -89,6 +87,7 @@ def main():
                         # env_policy=opts.env_policy,
                         env_policy="none",
                         event_policy=opts.event_policy,
+                        no_shuffle=opts.no_shuffle,
                         script_path=opts.script_path,
                         event_interval=opts.event_interval,
                         event_duration=opts.timeout,

--- a/droidbot/start.py
+++ b/droidbot/start.py
@@ -32,7 +32,9 @@ def parse_args():
                              # '%s\tsend events based on static analysis result; \n'
                              # '%s\tbased on dynamic app state, this policy requires framework instrumented\n'
                              '\"%s\"\tExplore the UI using a breadth-first strategy.\n'
+                             '\"%s\"\tExplore the UI using a breadth-first strategy, but without view shuffling\n'
                              '\"%s\"\tExplore the UI using a depth-first strategy.\n'
+                             '\"%s\"\tExplore the UI using a depth-first strategy, but without view shuffling\n'
                              # '<%s>\tUse a script to customize input for certain states.\n'
                              # '%s\tmanually interact with your app, and we will record the events.\n'
                              %
@@ -43,7 +45,9 @@ def parse_args():
                                  # app_event.POLICY_STATIC,
                                  # app_event.POLICY_DYNAMIC,
                                  app_event.POLICY_BFS,
+                                 app_event.POLICY_BFS_NO_SHUFFLE,
                                  app_event.POLICY_DFS,
+                                 app_event.POLICY_DFS_NO_SHUFFLE,
                                  # app_event.POLICY_FILE,
                                  # app_event.POLICY_MANUAL
                              ))


### PR DESCRIPTION
Add "bfs_no_shuffle" and "dfs_no_shuffle" to allow users to switch off the random.shuffle for views. This may be necessary for DroidBot to generate the same test sequences for multiple runs of a single app.