### PR TITLE
add grant permission option

### DIFF
--- a/droidbot/device.py
+++ b/droidbot/device.py
@@ -16,7 +16,8 @@ class Device(object):
     this class describes a connected device
     """
 
-    def __init__(self, device_serial, is_emulator=True, output_dir=None, use_hierarchy_viewer=False):
+    def __init__(self, device_serial, is_emulator=True, output_dir=None,
+                 use_hierarchy_viewer=False, grant_perm=False):
         """
         create a device
         :param device_serial: serial number of target device
@@ -45,6 +46,7 @@ class Device(object):
             os.mkdir(self.output_dir)
 
         self.use_hierarchy_viewer = use_hierarchy_viewer
+        self.grant_perm = grant_perm
 
         if self.is_emulator:
             self.adb_enabled = True
@@ -588,8 +590,12 @@ class Device(object):
         assert isinstance(app, App)
         subprocess.check_call(["adb", "-s", self.serial, "uninstall", app.get_package_name()],
                               stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        subprocess.check_call(["adb", "-s", self.serial, "install", app.app_path],
-                              stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
+        install_cmd = ["adb", "-s", self.serial, "install"]
+        if self.grant_perm:
+            install_cmd.append("-g")
+        install_cmd.append(app.app_path)
+        subprocess.check_call(install_cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
         package_info_file_name = "%s/dumpsys_package_%s.txt" % (self.output_dir, app.get_package_name())
         package_info_file = open(package_info_file_name, "w")

--- a/droidbot/droidbot.py
+++ b/droidbot/droidbot.py
@@ -25,7 +25,7 @@ class DroidBot(object):
                  env_policy=None, event_policy=None, no_shuffle=False, script_path=None,
                  event_count=None, event_interval=None, event_duration=None,
                  quiet=False, with_droidbox=False,
-                 use_hierarchy_viewer=False, profiling_method=None):
+                 use_hierarchy_viewer=False, profiling_method=None, grant_perm=False):
         """
         initiate droidbot with configurations
         :return:
@@ -47,7 +47,8 @@ class DroidBot(object):
         #     # FIXED by requiring device_serial in cmd
         #     device_serial = '.*'
 
-        self.device = Device(device_serial, output_dir=self.output_dir, use_hierarchy_viewer=use_hierarchy_viewer)
+        self.device = Device(device_serial, output_dir=self.output_dir,
+                             use_hierarchy_viewer=use_hierarchy_viewer, grant_perm=grant_perm)
         self.app = App(app_path, output_dir=self.output_dir)
 
         self.droidbox = None

--- a/droidbot/start.py
+++ b/droidbot/start.py
@@ -63,6 +63,9 @@ def parse_args():
                         help="Force use Hierarchy Viewer to dump UI states instead of UI Automator.")
     parser.add_argument("-use_method_profiling", action="store", dest="profiling_method",
                         help="Record method trace for each event. can be \"full\" or a sampling rate.")
+    parser.add_argument("-grant_perm", action="store_true", dest="grant_perm",
+                        help="Grant all runtime permissions while installing an app. "
+                             "May be necessary for Android versions after Marshmallow.")
     parser.add_argument("-use_with_droidbox", action="store_true", dest="with_droidbox",
                         help="Use DroidBot with DroidBox. Need to run on a DroidBox emulator.")
     options = parser.parse_args()
@@ -95,7 +98,8 @@ def main():
                         quiet=opts.quiet,
                         with_droidbox=opts.with_droidbox,
                         use_hierarchy_viewer=opts.use_hierarchy_viewer,
-                        profiling_method=opts.profiling_method)
+                        profiling_method=opts.profiling_method,
+                        grant_perm=opts.grant_perm)
     droidbot.start()
     return
 


### PR DESCRIPTION
Users can choose to grant all permissions silently when testing apps on Android versions higher than Marshmallow by using `-grant_perm` option.
This eliminates redundant permission confirm pop-up windows when there is no need.