### PR TITLE
minicap: fix minicap support problems

### DIFF
--- a/droidbot/device_state.py
+++ b/droidbot/device_state.py
@@ -131,7 +131,10 @@ class DeviceState(object):
             if not os.path.exists(output_dir):
                 os.mkdir(output_dir)
             dest_state_json_path = "%s/state_%s.json" % (output_dir, self.tag)
-            dest_screenshot_path = "%s/screen_%s.png" % (output_dir, self.tag)
+            if self.device.minicap:
+                dest_screenshot_path = "%s/screen_%s.jpg" % (output_dir, self.tag)
+            else:
+                dest_screenshot_path = "%s/screen_%s.png" % (output_dir, self.tag)
             state_json_file = open(dest_state_json_path, "w")
             state_json_file.write(self.to_json())
             state_json_file.close()
@@ -154,7 +157,10 @@ class DeviceState(object):
             if not os.path.exists(output_dir):
                 os.mkdir(output_dir)
             view_str = view_dict['view_str']
-            view_file_path = "%s/view_%s.png" % (output_dir, view_str)
+            if self.device.minicap:
+                view_file_path = "%s/view_%s.jpg" % (output_dir, view_str)
+            else:
+                view_file_path = "%s/view_%s.png" % (output_dir, view_str)
             if os.path.exists(view_file_path):
                 return
             from PIL import Image

--- a/droidbot/droidbot.py
+++ b/droidbot/droidbot.py
@@ -25,6 +25,7 @@ class DroidBot(object):
     def __init__(self,
                  app_path=None,
                  device_serial=None,
+                 is_emulator=False,
                  output_dir=None,
                  env_policy=None,
                  policy_name=None,
@@ -75,6 +76,7 @@ class DroidBot(object):
 
         try:
             self.device = Device(device_serial=device_serial,
+                                 is_emulator=is_emulator,
                                  output_dir=self.output_dir,
                                  cv_mode=cv_mode,
                                  grant_perm=grant_perm)

--- a/droidbot/start.py
+++ b/droidbot/start.py
@@ -63,6 +63,8 @@ def parse_args():
                         help="Record method trace for each event. can be \"full\" or a sampling rate.")
     parser.add_argument("-grant_perm", action="store_true", dest="grant_perm",
                         help="Grant all permissions while installing. Useful for Android 6.0+.")
+    parser.add_argument("-is_emulator", action="store_true", dest="is_emulator",
+                        help="Declare the target device to be an emulator, which would be treated specially by DroidBot.")
     options = parser.parse_args()
     # print options
     return options
@@ -83,6 +85,7 @@ def main():
 
     droidbot = DroidBot(app_path=opts.apk_path,
                         device_serial=opts.device_serial,
+                        is_emulator=opts.is_emulator,
                         output_dir=opts.output_dir,
                         # env_policy=opts.env_policy,
                         env_policy=env_manager.POLICY_NONE,

--- a/droidbot/utg.py
+++ b/droidbot/utg.py
@@ -127,7 +127,10 @@ class UTG(object):
             for event_id, event in zip(event_ids, events):
                 event_str = event.get_event_str(self.G.node[from_state]['state'])
                 event_short_descs.append((event_id, event_str))
-                view_images = ["views/view_" + view['view_str'] + ".png" for view in event.get_views()]
+                if self.device.minicap:
+                    view_images = ["views/view_" + view['view_str'] + ".jpg" for view in event.get_views()]
+                else:
+                    view_images = ["views/view_" + view['view_str'] + ".png" for view in event.get_views()]
                 event_list.append({
                     "event_str": event_str,
                     "event_id": event_id,


### PR DESCRIPTION
Currently the minicap support in DroidBot has the following
two problems:

1) Minicap will save screenshots in JPEG format, which is
now unhandled by DroidBot;
2) Minicap officially doesn't support emulators, causing
black blank screenshot on emulators.

This PR should fix the problems by
1) Use JPEG format when Minicap is enabled;
2) Disable Minicap when emulator is given by is_emulator
option.
