### PR TITLE
input_policy: refactor and bug fix

### DIFF
--- a/droidbot/input_manager.py
+++ b/droidbot/input_manager.py
@@ -4,14 +4,13 @@ import subprocess
 import time
 
 from input_event import EventLog
-from input_policy import UtgBasedInputPolicy, UtgDfsPolicy, ManualPolicy
+from input_policy import UtgBasedInputPolicy, UtgNaiveSearchPolicy, UtgGreedySearchPolicy, \
+                         ManualPolicy, \
+                         POLICY_NAIVE_DFS, POLICY_GREEDY_DFS, \
+                         POLICY_NAIVE_BFS, POLICY_GREEDY_BFS, \
+                         POLICY_MANUAL, POLICY_MONKEY, POLICY_NONE
 
-POLICY_NONE = "none"
-POLICY_MONKEY = "monkey"
-POLICY_DFS = "dfs"
-POLICY_MANUAL = "manual"
-
-DEFAULT_POLICY = POLICY_DFS
+DEFAULT_POLICY = POLICY_GREEDY_DFS
 DEFAULT_EVENT_INTERVAL = 1
 DEFAULT_EVENT_COUNT = 1000
 DEFAULT_TIMEOUT = -1
@@ -67,11 +66,14 @@ class InputManager(object):
             input_policy = None
         elif self.policy_name == POLICY_MONKEY:
             input_policy = None
-        elif self.policy_name == POLICY_DFS:
-            input_policy = UtgDfsPolicy(device, app, self.random_input)
+        elif self.policy_name in [POLICY_NAIVE_DFS, POLICY_NAIVE_BFS]:
+            input_policy = UtgNaiveSearchPolicy(device, app, self.random_input, self.policy_name)
+        elif self.policy_name in [POLICY_GREEDY_DFS, POLICY_GREEDY_BFS]:
+            input_policy = UtgGreedySearchPolicy(device, app, self.random_input, self.policy_name)
         elif self.policy_name == POLICY_MANUAL:
             input_policy = ManualPolicy(device, app)
         else:
+            self.logger.warning("No valid input policy specified. Using policy \"none\".")
             input_policy = None
         if isinstance(input_policy, UtgBasedInputPolicy):
             input_policy.script = self.script

--- a/droidbot/start.py
+++ b/droidbot/start.py
@@ -2,6 +2,7 @@
 # it parses command arguments and send the options to droidbot
 import argparse
 import input_manager
+import input_policy
 import env_manager
 from droidbot import DroidBot
 
@@ -30,12 +31,18 @@ def parse_args():
                              'Default: %s.\nSupported policies:\n' % input_manager.DEFAULT_POLICY +
                              '  \"%s\" -- No event will be sent, user should interact manually with device; \n'
                              '  \"%s\" -- Use "adb shell monkey" to send events; \n'
-                             '  \"%s\" -- Explore UI using a depth-first strategy.\n'
+                             '  \"%s\" -- Explore UI using a naive depth-first strategy;\n'
+                             '  \"%s\" -- Explore UI using a greedy depth-first strategy;\n'
+                             '  \"%s\" -- Explore UI using a naive breadth-first strategy;\n'
+                             '  \"%s\" -- Explore UI using a greedy breadth-first strategy;\n'
                              %
                              (
-                                 input_manager.POLICY_NONE,
-                                 input_manager.POLICY_MONKEY,
-                                 input_manager.POLICY_DFS,
+                                 input_policy.POLICY_NONE,
+                                 input_policy.POLICY_MONKEY,
+                                 input_policy.POLICY_NAIVE_DFS,
+                                 input_policy.POLICY_GREEDY_DFS,
+                                 input_policy.POLICY_NAIVE_BFS,
+                                 input_policy.POLICY_GREEDY_DFS,
                              ))
     parser.add_argument("-script", action="store", dest="script_path",
                         help="Use a script to customize input for certain states.")


### PR DESCRIPTION
This commit
1) merges the old bfs/dfs policy into UtgNaiveSearchPolicy;
2) merges the new bfs/dfs policy into UtgGreedySearchPolicy,
which needs further implementation and optimization;
3) fixes a bug in UtgNaiveSearchPolicy not using self.current_state
to update UTG;
4) adds a warning when no valid input policy is chosen.
