### PR TITLE
Get rid of subprocess.call subprocess.check_call with subprocess.PIPE parameters

### DIFF
--- a/droidbot/adapter/droidbot_app.py
+++ b/droidbot/adapter/droidbot_app.py
@@ -163,7 +163,9 @@ class DroidBotAppConn(Adapter):
                 print e.message
         try:
             forward_remove_cmd = "adb -s %s forward --remove tcp:%d" % (self.device.serial, self.port)
-            subprocess.check_call(forward_remove_cmd.split(), stderr=subprocess.PIPE, stdout=subprocess.PIPE)
+            p = subprocess.Popen(forward_remove_cmd.split(), stderr=subprocess.PIPE, stdout=subprocess.PIPE)
+            out, err = p.communicate()
+
         except Exception as e:
             print e.message
         self.__can_wait = False

--- a/droidbot/adapter/minicap.py
+++ b/droidbot/adapter/minicap.py
@@ -84,7 +84,8 @@ class Minicap(Adapter):
     def tear_down(self):
         try:
             delete_minicap_cmd = "adb -s %s shell rm -r %s" % (self.device.serial, self.remote_minicap_path)
-            subprocess.check_call(delete_minicap_cmd.split(), stderr=subprocess.PIPE, stdout=subprocess.PIPE)
+            p = subprocess.Popen(delete_minicap_cmd.split(), stderr=subprocess.PIPE, stdout=subprocess.PIPE)
+            out, err = p.communicate()
         except Exception:
             pass
 
@@ -111,8 +112,10 @@ class Minicap(Adapter):
         start_minicap_cmd = "adb -s %s shell LD_LIBRARY_PATH=%s %s/minicap -P %s" % \
                             (device.serial, self.remote_minicap_path, self.remote_minicap_path, size_opt)
         self.logger.debug("starting minicap: " + start_minicap_cmd)
-        subprocess.check_call(grant_minicap_perm_cmd.split(),
-                              stdin=subprocess.PIPE, stdout=subprocess.PIPE)
+
+        p = subprocess.Popen(grant_minicap_perm_cmd.split(), stderr=subprocess.PIPE, stdout=subprocess.PIPE)
+        out, err = p.communicate()
+
         self.minicap_process = subprocess.Popen(start_minicap_cmd.split(),
                                                 stdin=subprocess.PIPE, stdout=subprocess.PIPE)
         # Wait 2 seconds for starting minicap
@@ -256,7 +259,8 @@ class Minicap(Adapter):
                 print e.message
         try:
             forward_remove_cmd = "adb -s %s forward --remove tcp:%d" % (self.device.serial, self.port)
-            subprocess.check_call(forward_remove_cmd.split(), stderr=subprocess.PIPE, stdout=subprocess.PIPE)
+            p = subprocess.Popen(forward_remove_cmd.split(), stderr=subprocess.PIPE, stdout=subprocess.PIPE)
+            out, err = p.communicate()
         except Exception as e:
             print e.message
 


### PR DESCRIPTION
Those calls might cause deadlocks, it is not recommended to use them. See the note for subprocess.check_call in https://docs.python.org/2/library/subprocess.html

I faced such deadlocks in the old version of droidbot at the point of installing the application (in device.py). I see that in the currrent version it was substituted by subprocess.Popen but the other parts  of droidbot still use these buggy calls.