### PR TITLE
Enabling accessibility service automatically for old Android

### DIFF
--- a/droidbot/adapter/adb.py
+++ b/droidbot/adapter/adb.py
@@ -236,6 +236,8 @@ class ADB(Adapter):
         if service_name not in service_names:
             service_names.append(service_name)
             self.shell("settings put secure enabled_accessibility_services %s" % ":".join(service_names))
+        self.shell("settings put secure accessibility_enabled 1")
+
 
     def get_installed_apps(self):
         """

--- a/droidbot/adapter/adb.py
+++ b/droidbot/adapter/adb.py
@@ -215,7 +215,8 @@ class ADB(Adapter):
         :return: the enabled service names, each service name is in <package_name>/<service_name> format
         """
         r = self.shell("settings get secure enabled_accessibility_services")
-        return r.strip().split(":")
+        r = re.sub(r'(?m)^WARNING:.*\n?', '', r)
+        return r.strip().split(":") if r.strip() != '' else []
 
     def disable_accessibility_service(self, service_name):
         """

--- a/droidbot/adapter/droidbot_app.py
+++ b/droidbot/adapter/droidbot_app.py
@@ -48,6 +48,7 @@ class DroidBotAppConn(Adapter):
 
         self.sock = None
         self.last_acc_event = None
+        self.enable_accessibility_hard = device.enable_accessibility_hard
 
     def set_up(self):
         device = self.device
@@ -67,6 +68,13 @@ class DroidBotAppConn(Adapter):
 
         # device.adb.disable_accessibility_service(ACCESSIBILITY_SERVICE)
         device.adb.enable_accessibility_service(ACCESSIBILITY_SERVICE)
+
+        if  ACCESSIBILITY_SERVICE not in device.get_service_names() and \
+                   self.device.get_sdk_version() < 23 and self.enable_accessibility_hard:
+            device.adb.enable_accessibility_service_db(ACCESSIBILITY_SERVICE)
+            while ACCESSIBILITY_SERVICE not in device.get_service_names():
+                print "Restarting device..."
+                time.sleep(1)
 
         # device.start_app(droidbot_app)
         while ACCESSIBILITY_SERVICE not in device.get_service_names() and self.__can_wait:

--- a/droidbot/device.py
+++ b/droidbot/device.py
@@ -26,7 +26,7 @@ class Device(object):
     """
 
     def __init__(self, device_serial=None, is_emulator=False, output_dir=None,
-                 cv_mode=False, grant_perm=False, telnet_auth_token=None):
+                 cv_mode=False, grant_perm=False, telnet_auth_token=None, enable_accessibility_hard=False):
         """
         initialize a device connection
         :param device_serial: serial number of target device
@@ -50,6 +50,7 @@ class Device(object):
             if not os.path.isdir(output_dir):
                 os.mkdir(output_dir)
         self.grant_perm = grant_perm
+        self.enable_accessibility_hard = enable_accessibility_hard
 
         # basic device information
         self.settings = {}

--- a/droidbot/droidbot.py
+++ b/droidbot/droidbot.py
@@ -39,7 +39,8 @@ class DroidBot(object):
                  cv_mode=False,
                  debug_mode=False,
                  profiling_method=None,
-                 grant_perm=False):
+                 grant_perm=False,
+                 enable_accessibility_hard=False):
         """
         initiate droidbot with configurations
         :return:
@@ -71,6 +72,7 @@ class DroidBot(object):
         self.droidbox = None
         self.env_manager = None
         self.input_manager = None
+        self.enable_accessibility_hard = enable_accessibility_hard
 
         self.enabled = True
 
@@ -79,7 +81,8 @@ class DroidBot(object):
                                  is_emulator=is_emulator,
                                  output_dir=self.output_dir,
                                  cv_mode=cv_mode,
-                                 grant_perm=grant_perm)
+                                 grant_perm=grant_perm,
+                                 enable_accessibility_hard=self.enable_accessibility_hard)
             self.app = App(app_path, output_dir=self.output_dir)
 
             self.env_manager = AppEnvManager(device=self.device,

--- a/droidbot/start.py
+++ b/droidbot/start.py
@@ -72,6 +72,8 @@ def parse_args():
                         help="Grant all permissions while installing. Useful for Android 6.0+.")
     parser.add_argument("-is_emulator", action="store_true", dest="is_emulator",
                         help="Declare the target device to be an emulator, which would be treated specially by DroidBot.")
+    parser.add_argument("-accessibility_auto", action="store_true", dest="enable_accessibility_hard",
+                        help="Enable the accessibility service automatically even though it might require device restart\n(can be useful for Android API level < 23).")
     options = parser.parse_args()
     # print options
     return options
@@ -107,7 +109,8 @@ def main():
                         keep_app=opts.keep_app,
                         keep_env=opts.keep_env,
                         profiling_method=opts.profiling_method,
-                        grant_perm=opts.grant_perm)
+                        grant_perm=opts.grant_perm,
+                        enable_accessibility_hard=opts.enable_accessibility_hard)
     droidbot.start()
     return
 


### PR DESCRIPTION
Here are some fixes for automatically enabling droidbot accessibility service. The first and the second commit work for older Android that already has command `adb shell settings ...` The command for enabling accessibility in general was missed.

And the third commit is for Android that uses settings.db to store such settings (API level < 23).  However, it requires device restart so I've added an option -accessibility_auto to use this type of enabling. By default the user is required to enable the accessibility service manually.