### PR TITLE
Add Python3 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ DroidBot has the following advantages as compared with other input generators:
 
 ## Prerequisite
 
-1. `Python` version `2.7`
+1. `Python` version `3.5`
 2. `Java` version `1.7`
 3. `Android SDK`
 4. Add `platform_tools` directory in Android SDK to `PATH`
@@ -29,11 +29,11 @@ DroidBot has the following advantages as compared with other input generators:
 
 ## How to install
 
-Clone this repo and intall with `pip`:
+Clone this repo and install with `pip`:
 
 ```shell
 git clone https://github.com/honeynet/droidbot.git
-pip install -e droidbot
+pip install --process-dependency-links -e droidbot
 ```
 
 If successfully installed, you should be able to execute `droidbot -h`.

--- a/droidbot/__init__.py
+++ b/droidbot/__init__.py
@@ -1,4 +1,0 @@
-__author__ = 'liyc'
-
-from . import start
-start = start.main

--- a/droidbot/__init__.py
+++ b/droidbot/__init__.py
@@ -1,4 +1,4 @@
 __author__ = 'liyc'
 
-import start
+from . import start
 start = start.main

--- a/droidbot/adapter/adb.py
+++ b/droidbot/adapter/adb.py
@@ -2,7 +2,7 @@
 import subprocess
 import logging
 import re
-from adapter import Adapter
+from .adapter import Adapter
 
 
 class ADBException(Exception):

--- a/droidbot/adapter/adb.py
+++ b/droidbot/adapter/adb.py
@@ -1,8 +1,10 @@
 # This is the interface for adb
-import subprocess
+
 import logging
 import re
-from .adapter import Adapter
+import subprocess
+
+from droidbot.adapter.adapter import Adapter
 
 
 class ADBException(Exception):

--- a/droidbot/adapter/adb.py
+++ b/droidbot/adapter/adb.py
@@ -60,7 +60,7 @@ class ADB(Adapter):
 
         self.logger.debug('command:')
         self.logger.debug(args)
-        r = subprocess.check_output(args).strip()
+        r = subprocess.check_output(args).strip().decode()
         self.logger.debug('return:')
         self.logger.debug(r)
         return r

--- a/droidbot/adapter/adb.py
+++ b/droidbot/adapter/adb.py
@@ -99,7 +99,7 @@ class ADB(Adapter):
         """
         disconnect adb
         """
-        print "[CONNECTION] %s is disconnected" % self.__class__.__name__
+        print("[CONNECTION] %s is disconnected" % self.__class__.__name__)
 
     def get_property(self, property):
         """
@@ -258,7 +258,8 @@ class ADB(Adapter):
         else:
             return -1.0
 
-    def __transform_point_by_orientation(self, (x, y), orientation_orig, orientation_dest):
+    def __transform_point_by_orientation(self, point, orientation_orig, orientation_dest):
+        (x, y) = point
         if orientation_orig != orientation_dest:
             if orientation_dest == 1:
                 _x = x
@@ -305,14 +306,16 @@ class ADB(Adapter):
         """
         self.drag((x, y), (x, y), duration, orientation)
 
-    def drag(self, (x0, y0), (x1, y1), duration, orientation=-1):
+    def drag(self, start_point, end_point, duration, orientation=-1):
         """
         Sends drag event n PX (actually it's using C{input swipe} command.
-        @param (x0, y0): starting point in pixel
-        @param (x1, y1): ending point in pixel
+        @param start_point: starting point in pixel
+        @param end_point: ending point in pixel
         @param duration: duration of the event in ms
         @param orientation: the orientation (-1: undefined)
         """
+        (x0, y0) = start_point
+        (x1, y1) = end_point
         if orientation == -1:
             orientation = self.get_orientation()
         (x0, y0) = self.__transform_point_by_orientation((x0, y0), orientation, self.get_orientation())

--- a/droidbot/adapter/adb.py
+++ b/droidbot/adapter/adb.py
@@ -48,7 +48,7 @@ class ADB(Adapter):
         :return: output of adb command
         @param extra_args: arguments to run in adb
         """
-        if isinstance(extra_args, str) or isinstance(extra_args, unicode):
+        if isinstance(extra_args, str):
             extra_args = extra_args.split()
         if not isinstance(extra_args, list):
             msg = "invalid arguments: %s\nshould be list or str, %s given" % (extra_args, type(extra_args))
@@ -71,7 +71,7 @@ class ADB(Adapter):
         @param extra_args:
         @return: output of adb shell command
         """
-        if isinstance(extra_args, str) or isinstance(extra_args, unicode):
+        if isinstance(extra_args, str):
             extra_args = extra_args.split()
         if not isinstance(extra_args, list):
             msg = "invalid arguments: %s\nshould be list or str, %s given" % (extra_args, type(extra_args))

--- a/droidbot/adapter/droidbot_app.py
+++ b/droidbot/adapter/droidbot_app.py
@@ -160,12 +160,12 @@ class DroidBotAppConn(Adapter):
             try:
                 self.sock.close()
             except Exception as e:
-                print(e.message)
+                print(e)
         try:
             forward_remove_cmd = "adb -s %s forward --remove tcp:%d" % (self.device.serial, self.port)
             subprocess.check_call(forward_remove_cmd.split(), stderr=subprocess.PIPE, stdout=subprocess.PIPE)
         except Exception as e:
-            print(e.message)
+            print(e)
         self.__can_wait = False
 
     def __view_tree_to_list(self, view_tree, view_list):

--- a/droidbot/adapter/droidbot_app.py
+++ b/droidbot/adapter/droidbot_app.py
@@ -70,7 +70,7 @@ class DroidBotAppConn(Adapter):
 
         # device.start_app(droidbot_app)
         while ACCESSIBILITY_SERVICE not in device.get_service_names() and self.__can_wait:
-            print "Please enable accessibility for DroidBot app manually."
+            print("Please enable accessibility for DroidBot app manually.")
             time.sleep(1)
 
     def tear_down(self):
@@ -115,7 +115,7 @@ class DroidBotAppConn(Adapter):
                 _, _, message_len = self.read_head()
                 message = self.sock_read(message_len)
                 self.handle_message(message)
-            print "[CONNECTION] %s is disconnected" % self.__class__.__name__
+            print("[CONNECTION] %s is disconnected" % self.__class__.__name__)
         except Exception as ex:
             if self.check_connectivity():
                 # clear self.last_acc_event
@@ -160,12 +160,12 @@ class DroidBotAppConn(Adapter):
             try:
                 self.sock.close()
             except Exception as e:
-                print e.message
+                print(e.message)
         try:
             forward_remove_cmd = "adb -s %s forward --remove tcp:%d" % (self.device.serial, self.port)
             subprocess.check_call(forward_remove_cmd.split(), stderr=subprocess.PIPE, stdout=subprocess.PIPE)
         except Exception as e:
-            print e.message
+            print(e.message)
         self.__can_wait = False
 
     def __view_tree_to_list(self, view_tree, view_list):

--- a/droidbot/adapter/droidbot_app.py
+++ b/droidbot/adapter/droidbot_app.py
@@ -4,7 +4,7 @@ import subprocess
 import time
 import json
 import struct
-from adapter import Adapter
+from .adapter import Adapter
 
 DROIDBOT_APP_REMOTE_ADDR = "tcp:7336"
 DROIDBOT_APP_PACKAGE = "io.github.ylimit.droidbotapp"

--- a/droidbot/adapter/droidbot_ime.py
+++ b/droidbot/adapter/droidbot_ime.py
@@ -3,7 +3,7 @@
 import logging
 import time
 
-from adapter import Adapter
+from .adapter import Adapter
 
 DROIDBOT_APP_PACKAGE = "io.github.ylimit.droidbotapp"
 IME_SERVICE = DROIDBOT_APP_PACKAGE + "/.DroidBotIME"

--- a/droidbot/adapter/droidbot_ime.py
+++ b/droidbot/adapter/droidbot_ime.py
@@ -76,7 +76,7 @@ class DroidBotIme(Adapter):
         r_disable = self.device.adb.shell("ime disable %s" % IME_SERVICE)
         if r_disable.endswith("now disabled"):
             self.connected = False
-            print "[CONNECTION] %s is disconnected" % self.__class__.__name__
+            print("[CONNECTION] %s is disconnected" % self.__class__.__name__)
             return
         self.logger.warning("Failed to disconnect DroidBotIME!")
 

--- a/droidbot/adapter/droidbot_ime.py
+++ b/droidbot/adapter/droidbot_ime.py
@@ -3,7 +3,7 @@
 import logging
 import time
 
-from .adapter import Adapter
+from droidbot.adapter.adapter import Adapter
 
 DROIDBOT_APP_PACKAGE = "io.github.ylimit.droidbotapp"
 IME_SERVICE = DROIDBOT_APP_PACKAGE + "/.DroidBotIME"
@@ -46,7 +46,7 @@ class DroidBotIme(Adapter):
                 self.device.adb.run_cmd(install_cmd)
                 self.logger.debug("DroidBot app installed.")
             except Exception as e:
-                self.logger.warning(e.message)
+                self.logger.warning(e)
                 self.logger.warning("Failed to install DroidBotApp.")
 
     def tear_down(self):

--- a/droidbot/adapter/jdwp.py
+++ b/droidbot/adapter/jdwp.py
@@ -1,7 +1,7 @@
 import logging
 import socket
 
-from adapter import Adapter
+from .adapter import Adapter
 
 
 class JDWPException(Exception):

--- a/droidbot/adapter/jdwp.py
+++ b/droidbot/adapter/jdwp.py
@@ -55,7 +55,7 @@ class JDWP(Adapter):
             try:
                 self.sock.close()
             except Exception as e:
-                print e.message
+                print(e.message)
         # TODO
 
 

--- a/droidbot/adapter/jdwp.py
+++ b/droidbot/adapter/jdwp.py
@@ -1,7 +1,7 @@
 import logging
 import socket
 
-from .adapter import Adapter
+from droidbot.adapter.adapter import Adapter
 
 
 class JDWPException(Exception):
@@ -55,7 +55,7 @@ class JDWP(Adapter):
             try:
                 self.sock.close()
             except Exception as e:
-                print(e.message)
+                print(e)
         # TODO
 
 

--- a/droidbot/adapter/logcat.py
+++ b/droidbot/adapter/logcat.py
@@ -1,6 +1,6 @@
 import subprocess
 import logging
-from adapter import Adapter
+from .adapter import Adapter
 
 
 class Logcat(Adapter):

--- a/droidbot/adapter/logcat.py
+++ b/droidbot/adapter/logcat.py
@@ -1,6 +1,7 @@
-import subprocess
 import logging
-from .adapter import Adapter
+import subprocess
+
+from droidbot.adapter.adapter import Adapter
 
 
 class Logcat(Adapter):

--- a/droidbot/adapter/logcat.py
+++ b/droidbot/adapter/logcat.py
@@ -60,7 +60,7 @@ class Logcat(Adapter):
 
         if f is not None:
             f.close()
-        print "[CONNECTION] %s is disconnected" % self.__class__.__name__
+        print("[CONNECTION] %s is disconnected" % self.__class__.__name__)
 
     def parse_line(self, logcat_line):
         pass

--- a/droidbot/adapter/minicap.py
+++ b/droidbot/adapter/minicap.py
@@ -204,7 +204,7 @@ class Minicap(Adapter):
                         frameBodyLength -= chunk_len - cursor
                         readFrameBytes += chunk_len - cursor
                         cursor = chunk_len
-        print "[CONNECTION] %s is disconnected" % self.__class__.__name__
+        print("[CONNECTION] %s is disconnected" % self.__class__.__name__)
 
     def handle_image(self, frameBody):
         # Sanity check for JPG header, only here for debugging purposes.
@@ -248,17 +248,17 @@ class Minicap(Adapter):
             try:
                 self.sock.close()
             except Exception as e:
-                print e.message
+                print(e.message)
         if self.minicap_process is not None:
             try:
                 self.minicap_process.terminate()
             except Exception as e:
-                print e.message
+                print(e.message)
         try:
             forward_remove_cmd = "adb -s %s forward --remove tcp:%d" % (self.device.serial, self.port)
             subprocess.check_call(forward_remove_cmd.split(), stderr=subprocess.PIPE, stdout=subprocess.PIPE)
         except Exception as e:
-            print e.message
+            print(e.message)
 
     def get_views(self):
         """

--- a/droidbot/adapter/minicap.py
+++ b/droidbot/adapter/minicap.py
@@ -3,7 +3,7 @@ import socket
 import subprocess
 import time
 from datetime import datetime
-from adapter import Adapter
+from .adapter import Adapter
 
 MINICAP_REMOTE_ADDR = "localabstract:minicap"
 ROTATION_CHECK_INTERVAL_S = 1 # Check rotation once per second

--- a/droidbot/adapter/minicap.py
+++ b/droidbot/adapter/minicap.py
@@ -3,10 +3,11 @@ import socket
 import subprocess
 import time
 from datetime import datetime
-from .adapter import Adapter
+
+from droidbot.adapter.adapter import Adapter
 
 MINICAP_REMOTE_ADDR = "localabstract:minicap"
-ROTATION_CHECK_INTERVAL_S = 1 # Check rotation once per second
+ROTATION_CHECK_INTERVAL_S = 1  # Check rotation once per second
 
 
 class MinicapException(Exception):
@@ -248,17 +249,17 @@ class Minicap(Adapter):
             try:
                 self.sock.close()
             except Exception as e:
-                print(e.message)
+                print(e)
         if self.minicap_process is not None:
             try:
                 self.minicap_process.terminate()
             except Exception as e:
-                print(e.message)
+                print(e)
         try:
             forward_remove_cmd = "adb -s %s forward --remove tcp:%d" % (self.device.serial, self.port)
             subprocess.check_call(forward_remove_cmd.split(), stderr=subprocess.PIPE, stdout=subprocess.PIPE)
         except Exception as e:
-            print(e.message)
+            print(e)
 
     def get_views(self):
         """

--- a/droidbot/adapter/process_monitor.py
+++ b/droidbot/adapter/process_monitor.py
@@ -2,7 +2,7 @@ import threading
 import logging
 import time
 import subprocess
-from adapter import Adapter
+from .adapter import Adapter
 
 
 class ProcessMonitor(Adapter):

--- a/droidbot/adapter/process_monitor.py
+++ b/droidbot/adapter/process_monitor.py
@@ -1,8 +1,9 @@
-import threading
 import logging
-import time
 import subprocess
-from .adapter import Adapter
+import threading
+import time
+
+from droidbot.adapter.adapter import Adapter
 
 
 class ProcessMonitor(Adapter):
@@ -71,7 +72,7 @@ class ProcessMonitor(Adapter):
                 ps_cmd = ["adb", "shell", "ps"]
 
             try:
-                ps_out = subprocess.check_output(ps_cmd)
+                ps_out = subprocess.check_output(ps_cmd).decode()
             except subprocess.CalledProcessError:
                 continue
 

--- a/droidbot/adapter/process_monitor.py
+++ b/droidbot/adapter/process_monitor.py
@@ -97,7 +97,7 @@ class ProcessMonitor(Adapter):
                 self.lock.release()
 
             time.sleep(1)
-        print "[CONNECTION] %s is disconnected" % self.__class__.__name__
+        print("[CONNECTION] %s is disconnected" % self.__class__.__name__)
 
     def get_ppids_by_pid(self, pid):
         """

--- a/droidbot/adapter/telnet.py
+++ b/droidbot/adapter/telnet.py
@@ -1,6 +1,6 @@
 import logging
 import threading
-from adapter import Adapter
+from .adapter import Adapter
 
 
 class TelnetException(Exception):

--- a/droidbot/adapter/telnet.py
+++ b/droidbot/adapter/telnet.py
@@ -97,4 +97,4 @@ class TelnetConsole(Adapter):
         """
         if self.console is not None:
             self.console.close()
-        print "[CONNECTION] %s is disconnected" % self.__class__.__name__
+        print("[CONNECTION] %s is disconnected" % self.__class__.__name__)

--- a/droidbot/adapter/telnet.py
+++ b/droidbot/adapter/telnet.py
@@ -1,6 +1,7 @@
 import logging
 import threading
-from .adapter import Adapter
+
+from droidbot.adapter.adapter import Adapter
 
 
 class TelnetException(Exception):

--- a/droidbot/adapter/user_input_monitor.py
+++ b/droidbot/adapter/user_input_monitor.py
@@ -1,6 +1,6 @@
 import subprocess
 import logging
-from adapter import Adapter
+from .adapter import Adapter
 
 
 class UserInputMonitor(Adapter):

--- a/droidbot/adapter/user_input_monitor.py
+++ b/droidbot/adapter/user_input_monitor.py
@@ -1,6 +1,7 @@
-import subprocess
 import logging
-from .adapter import Adapter
+import subprocess
+
+from droidbot.adapter.adapter import Adapter
 
 
 class UserInputMonitor(Adapter):

--- a/droidbot/adapter/user_input_monitor.py
+++ b/droidbot/adapter/user_input_monitor.py
@@ -61,7 +61,7 @@ class UserInputMonitor(Adapter):
 
         if f is not None:
             f.close()
-        print "[CONNECTION] %s is disconnected" % self.__class__.__name__
+        print("[CONNECTION] %s is disconnected" % self.__class__.__name__)
 
     def parse_line(self, getevent_line):
         pass

--- a/droidbot/app.py
+++ b/droidbot/app.py
@@ -1,7 +1,7 @@
 import logging
 import os
 import hashlib
-from intent import Intent
+from .intent import Intent
 
 
 class App(object):

--- a/droidbot/app.py
+++ b/droidbot/app.py
@@ -1,7 +1,8 @@
+import hashlib
 import logging
 import os
-import hashlib
-from .intent import Intent
+
+from droidbot.intent import Intent
 
 
 class App(object):
@@ -73,7 +74,7 @@ class App(object):
         """
         if self.activities is None:
             self.activities = {}
-            manifest = self.get_androguard_analysis().a.get_AndroidManifest()
+            manifest = self.get_androguard_analysis().a.get_android_manifest_xml()
             for activity_dom in manifest.getElementsByTagName("activity"):
                 activity_name = None
                 activity_attrs = {}

--- a/droidbot/device.py
+++ b/droidbot/device.py
@@ -5,16 +5,16 @@ import subprocess
 import sys
 import time
 
-from adapter.adb import ADB
-from adapter.droidbot_app import DroidBotAppConn
-from adapter.logcat import Logcat
-from adapter.minicap import Minicap
-from adapter.process_monitor import ProcessMonitor
-from adapter.telnet import TelnetConsole
-from adapter.user_input_monitor import UserInputMonitor
-from adapter.droidbot_ime import DroidBotIme
-from app import App
-from intent import Intent
+from .adapter.adb import ADB
+from .adapter.droidbot_app import DroidBotAppConn
+from .adapter.logcat import Logcat
+from .adapter.minicap import Minicap
+from .adapter.process_monitor import ProcessMonitor
+from .adapter.telnet import TelnetConsole
+from .adapter.user_input_monitor import UserInputMonitor
+from .adapter.droidbot_ime import DroidBotIme
+from .app import App
+from .intent import Intent
 
 DEFAULT_NUM = '1234567890'
 DEFAULT_CONTENT = 'Hello world!'

--- a/droidbot/device.py
+++ b/droidbot/device.py
@@ -822,13 +822,15 @@ class Device(object):
         """
         self.adb.long_touch(x, y, duration)
 
-    def view_drag(self, (x0, y0), (x1, y1), duration):
+    def view_drag(self, start_point, end_point, duration):
         """
         Sends drag event n PX (actually it's using C{input swipe} command.
-        @param (x0, y0): starting point in PX
-        @param (x1, y1): ending point in PX
+        @param start_point: starting point in PX
+        @param end_point: ending point in PX
         @param duration: duration of the event in ms
         """
+        (x0, y0) = start_point
+        (x1, y1) = end_point
         self.adb.drag((x0, y0), (x1, y1), duration)
 
     def view_append_text(self, text):

--- a/droidbot/device.py
+++ b/droidbot/device.py
@@ -5,16 +5,18 @@ import subprocess
 import sys
 import time
 
-from .adapter.adb import ADB
-from .adapter.droidbot_app import DroidBotAppConn
-from .adapter.logcat import Logcat
-from .adapter.minicap import Minicap
-from .adapter.process_monitor import ProcessMonitor
-from .adapter.telnet import TelnetConsole
-from .adapter.user_input_monitor import UserInputMonitor
-from .adapter.droidbot_ime import DroidBotIme
-from .app import App
-from .intent import Intent
+from droidbot import utils
+from droidbot.adapter.adb import ADB
+from droidbot.adapter.droidbot_app import DroidBotAppConn
+from droidbot.adapter.droidbot_ime import DroidBotIme
+from droidbot.adapter.logcat import Logcat
+from droidbot.adapter.minicap import Minicap
+from droidbot.adapter.process_monitor import ProcessMonitor
+from droidbot.adapter.telnet import TelnetConsole
+from droidbot.adapter.user_input_monitor import UserInputMonitor
+from droidbot.app import App
+from droidbot.device_state import DeviceState
+from droidbot.intent import Intent
 
 DEFAULT_NUM = '1234567890'
 DEFAULT_CONTENT = 'Hello world!'
@@ -36,7 +38,6 @@ class Device(object):
         self.logger = logging.getLogger(self.__class__.__name__)
 
         if device_serial is None:
-            from . import utils
             all_devices = utils.get_available_devices()
             if len(all_devices) == 0:
                 self.logger.warning("ERROR: No device connected.")
@@ -646,7 +647,7 @@ class Device(object):
         cur_categories = []
 
         for line in lines:
-            line = line.strip()
+            line = line.strip().decode()
             m = activity_line_re.match(line)
             if m:
                 activities[cur_activity] = {
@@ -704,7 +705,7 @@ class Device(object):
             package = app
 
         name2pid = {}
-        ps_out = self.adb.shell(["ps"])
+        ps_out = self.adb.shell(["ps"]).decode()
         ps_out_lines = ps_out.splitlines()
         ps_out_head = ps_out_lines[0].split()
         if ps_out_head[1] != "PID" or ps_out_head[-1] != "NAME":
@@ -791,7 +792,6 @@ class Device(object):
             background_services = self.get_service_names()
             screenshot_path = self.take_screenshot()
             self.logger.debug("finish getting current device state...")
-            from device_state import DeviceState
             current_state = DeviceState(self,
                                         views=views,
                                         foreground_activity=foreground_activity,

--- a/droidbot/device.py
+++ b/droidbot/device.py
@@ -36,7 +36,7 @@ class Device(object):
         self.logger = logging.getLogger(self.__class__.__name__)
 
         if device_serial is None:
-            import utils
+            from . import utils
             all_devices = utils.get_available_devices()
             if len(all_devices) == 0:
                 self.logger.warning("ERROR: No device connected.")

--- a/droidbot/device.py
+++ b/droidbot/device.py
@@ -98,12 +98,12 @@ class Device(object):
             adapter_name = adapter.__class__.__name__
             adapter_enabled = self.adapters[adapter]
             if not adapter_enabled:
-                print "[CONNECTION] %s is not enabled." % adapter_name
+                print("[CONNECTION] %s is not enabled." % adapter_name)
             else:
                 if adapter.check_connectivity():
-                    print "[CONNECTION] %s is enabled and connected." % adapter_name
+                    print("[CONNECTION] %s is enabled and connected." % adapter_name)
                 else:
-                    print "[CONNECTION] %s is enabled but not connected." % adapter_name
+                    print("[CONNECTION] %s is enabled but not connected." % adapter_name)
 
     def wait_for_device(self):
         """
@@ -607,7 +607,7 @@ class Device(object):
             install_cmd.append(app.app_path)
             install_p = subprocess.Popen(install_cmd, stdout=subprocess.PIPE)
             while self.connected and package_name not in self.adb.get_installed_apps():
-                print "Please wait while installing the app..."
+                print("Please wait while installing the app...")
                 time.sleep(2)
             if not self.connected:
                 install_p.terminate()
@@ -693,7 +693,7 @@ class Device(object):
             uninstall_cmd = ["adb", "-s", self.serial, "uninstall", package_name]
             uninstall_p = subprocess.Popen(uninstall_cmd, stdout=subprocess.PIPE)
             while package_name in self.adb.get_installed_apps():
-                print "Please wait while uninstalling the app..."
+                print("Please wait while uninstalling the app...")
                 time.sleep(2)
             uninstall_p.terminate()
 
@@ -889,5 +889,5 @@ class Device(object):
             self.minicap.connect()
 
         if self.minicap.check_connectivity():
-            print "[CONNECTION] %s is reconnected." % self.minicap.__class__.__name__
+            print("[CONNECTION] %s is reconnected." % self.minicap.__class__.__name__)
         self.pause_sending_event = False

--- a/droidbot/device_state.py
+++ b/droidbot/device_state.py
@@ -1,7 +1,7 @@
 import math
 import os
 import utils
-from input_event import KeyEvent, TouchEvent, LongTouchEvent, ScrollEvent
+from .input_event import KeyEvent, TouchEvent, LongTouchEvent, ScrollEvent
 
 
 class DeviceState(object):

--- a/droidbot/device_state.py
+++ b/droidbot/device_state.py
@@ -1,6 +1,6 @@
 import math
 import os
-import utils
+from . import utils
 from .input_event import KeyEvent, TouchEvent, LongTouchEvent, ScrollEvent
 
 

--- a/droidbot/device_state.py
+++ b/droidbot/device_state.py
@@ -1,7 +1,8 @@
 import math
 import os
-from . import utils
-from .input_event import KeyEvent, TouchEvent, LongTouchEvent, ScrollEvent
+
+from droidbot import utils
+from droidbot.input_event import TouchEvent, ScrollEvent, LongTouchEvent
 
 
 class DeviceState(object):
@@ -144,7 +145,7 @@ class DeviceState(object):
             # if isinstance(self.screenshot_path, Image):
             #     self.screenshot_path.save(dest_screenshot_path)
         except Exception as e:
-            self.device.logger.warning("saving state to dir failed: " + e.message)
+            self.device.logger.warning("saving state to dir failed: " + e)
 
     def save_view_img(self, view_dict, output_dir=None):
         try:
@@ -173,7 +174,7 @@ class DeviceState(object):
                                           min(original_img.height, max(0, view_bound[1][1]))))
             view_img.save(view_file_path)
         except Exception as e:
-            self.device.logger.warning("saving view to dir failed: " + e.message)
+            self.device.logger.warning("saving view to dir failed: " + e)
 
     def is_different_from(self, another_state):
         """

--- a/droidbot/droidbot.py
+++ b/droidbot/droidbot.py
@@ -9,10 +9,10 @@ import pkg_resources
 import shutil
 from threading import Timer
 
-from device import Device
-from app import App
-from env_manager import AppEnvManager
-from input_manager import InputManager
+from .device import Device
+from .app import App
+from .env_manager import AppEnvManager
+from .input_manager import InputManager
 
 
 class DroidBot(object):

--- a/droidbot/droidbot.py
+++ b/droidbot/droidbot.py
@@ -103,7 +103,7 @@ class DroidBot(object):
     @staticmethod
     def get_instance():
         if DroidBot.instance is None:
-            print "Error: DroidBot is not initiated!"
+            print("Error: DroidBot is not initiated!")
             sys.exit(-1)
         return DroidBot.instance
 

--- a/droidbot/droidbot.py
+++ b/droidbot/droidbot.py
@@ -94,7 +94,7 @@ class DroidBot(object):
                                               script_path=script_path,
                                               profiling_method=profiling_method)
         except Exception as e:
-            self.logger.warning("Something went wrong: " + e.message)
+            self.logger.warning("Something went wrong: {0}".format(e))
             import traceback
             traceback.print_exc()
             self.stop()
@@ -148,7 +148,7 @@ class DroidBot(object):
             self.logger.info("Keyboard interrupt.")
             pass
         except Exception as e:
-            self.logger.warning("Something went wrong: " + e.message)
+            self.logger.warning("Something went wrong: {0}".format(e))
             import traceback
             traceback.print_exc()
             self.stop()

--- a/droidbot/droidbot.py
+++ b/droidbot/droidbot.py
@@ -2,17 +2,18 @@
 # It can be used after AVD was started, app was installed, and adb had been set up properly
 # By configuring and creating a droidbot instance,
 # droidbot will start interacting with Android in AVD like a human
+
 import logging
 import os
-import sys
-import pkg_resources
 import shutil
+import sys
 from threading import Timer
 
-from .device import Device
-from .app import App
-from .env_manager import AppEnvManager
-from .input_manager import InputManager
+import pkg_resources
+
+from droidbot.app import App
+from droidbot.device import Device
+from droidbot.env_manager import AppEnvManager
 
 
 class DroidBot(object):
@@ -85,6 +86,9 @@ class DroidBot(object):
             self.env_manager = AppEnvManager(device=self.device,
                                              app=self.app,
                                              env_policy=env_policy)
+
+            # This import has to be here and not at the top of the file to avoid a circular dependency error.
+            from droidbot.input_manager import InputManager
             self.input_manager = InputManager(device=self.device,
                                               app=self.app,
                                               policy_name=policy_name,

--- a/droidbot/env_manager.py
+++ b/droidbot/env_manager.py
@@ -5,10 +5,11 @@
 # The environment should be determined before app start running.
 # We don't need to set up all environments for one app,
 # instead we select a subset according to static analysis result of app.
-import logging
+
 import json
-import time
+import logging
 import os
+import time
 
 POLICY_NONE = "none"
 POLICY_DUMMY = "dummy"

--- a/droidbot/input_event.py
+++ b/droidbot/input_event.py
@@ -225,7 +225,7 @@ class EventLog(object):
         self.from_state = self.device.get_current_state()
         self.start_profiling()
         self.event_str = self.event.get_event_str(self.from_state)
-        print "Input: %s" % self.event_str
+        print("Input: %s" % self.event_str)
         self.device.send_event(self.event)
 
     def start_profiling(self):

--- a/droidbot/input_event.py
+++ b/droidbot/input_event.py
@@ -4,8 +4,8 @@ import random
 import time
 from abc import abstractmethod
 
-import utils
-from intent import Intent
+from . import utils
+from .intent import Intent
 
 POSSIBLE_KEYS = [
     "BACK",

--- a/droidbot/input_event.py
+++ b/droidbot/input_event.py
@@ -4,8 +4,8 @@ import random
 import time
 from abc import abstractmethod
 
-from . import utils
-from .intent import Intent
+from droidbot import utils
+from droidbot.intent import Intent
 
 POSSIBLE_KEYS = [
     "BACK",
@@ -202,7 +202,7 @@ class EventLog(object):
             json.dump(self.to_dict(), event_json_file, indent=2)
             event_json_file.close()
         except Exception as e:
-            self.device.logger.warning("Saving event to dir failed: " + e.message)
+            self.device.logger.warning("Saving event to dir failed: " + e)
 
     def save_views(self, output_dir=None):
         # Save views
@@ -288,7 +288,7 @@ class EventLog(object):
             self.device.pull_file(self.trace_remote_file, event_trace_local_path)
 
         except Exception as e:
-            self.device.logger.warning("profiling event failed: " + e.message)
+            self.device.logger.warning("profiling event failed: " + e)
 
 
 class ManualEvent(InputEvent):
@@ -391,7 +391,8 @@ class UIEvent(InputEvent):
         if x and y:
             return x, y
         if view:
-            from device_state import DeviceState
+            # This import has to be here and not at the top of the file to avoid a circular dependency error.
+            from droidbot.device_state import DeviceState
             return DeviceState.get_view_center(view_dict=view)
         return x, y
 
@@ -563,7 +564,8 @@ class ScrollEvent(UIEvent):
 
     def send(self, device):
         if self.view is not None:
-            from device_state import DeviceState
+            # This import has to be here and not at the top of the file to avoid a circular dependency error.
+            from droidbot.device_state import DeviceState
             width = DeviceState.get_view_width(view_dict=self.view)
             height = DeviceState.get_view_height(view_dict=self.view)
         else:

--- a/droidbot/input_manager.py
+++ b/droidbot/input_manager.py
@@ -3,12 +3,12 @@ import logging
 import subprocess
 import time
 
-from input_event import EventLog
-from input_policy import UtgBasedInputPolicy, UtgNaiveSearchPolicy, UtgGreedySearchPolicy, \
-                         ManualPolicy, \
-                         POLICY_NAIVE_DFS, POLICY_GREEDY_DFS, \
-                         POLICY_NAIVE_BFS, POLICY_GREEDY_BFS, \
-                         POLICY_MANUAL, POLICY_MONKEY, POLICY_NONE
+from .input_event import EventLog
+from .input_policy import UtgBasedInputPolicy, UtgNaiveSearchPolicy, UtgGreedySearchPolicy, \
+                          ManualPolicy, \
+                          POLICY_NAIVE_DFS, POLICY_GREEDY_DFS, \
+                          POLICY_NAIVE_BFS, POLICY_GREEDY_BFS, \
+                          POLICY_MANUAL, POLICY_MONKEY, POLICY_NONE
 
 DEFAULT_POLICY = POLICY_GREEDY_DFS
 DEFAULT_EVENT_INTERVAL = 1

--- a/droidbot/input_manager.py
+++ b/droidbot/input_manager.py
@@ -131,7 +131,7 @@ class InputManager(object):
             elif self.policy_name == POLICY_MANUAL:
                 self.device.start_app(self.app)
                 while self.enabled:
-                    keyboard_input = raw_input("press ENTER to save current state, type q to exit...")
+                    keyboard_input = input("press ENTER to save current state, type q to exit...")
                     if keyboard_input.startswith('q'):
                         break
                     state = self.device.get_current_state()

--- a/droidbot/input_manager.py
+++ b/droidbot/input_manager.py
@@ -3,12 +3,11 @@ import logging
 import subprocess
 import time
 
-from .input_event import EventLog
-from .input_policy import UtgBasedInputPolicy, UtgNaiveSearchPolicy, UtgGreedySearchPolicy, \
-                          ManualPolicy, \
-                          POLICY_NAIVE_DFS, POLICY_GREEDY_DFS, \
-                          POLICY_NAIVE_BFS, POLICY_GREEDY_BFS, \
-                          POLICY_MANUAL, POLICY_MONKEY, POLICY_NONE
+from droidbot.input_script import DroidBotScript
+from droidbot.input_event import EventLog
+from droidbot.input_policy import UtgBasedInputPolicy, UtgNaiveSearchPolicy, UtgGreedySearchPolicy, \
+    ManualPolicy, POLICY_NAIVE_DFS, POLICY_GREEDY_DFS, POLICY_NAIVE_BFS, POLICY_GREEDY_BFS, \
+    POLICY_MANUAL, POLICY_MONKEY, POLICY_NONE
 
 DEFAULT_POLICY = POLICY_GREEDY_DFS
 DEFAULT_EVENT_INTERVAL = 1
@@ -54,7 +53,6 @@ class InputManager(object):
         if script_path is not None:
             f = open(script_path, 'r')
             script_dict = json.load(f)
-            from input_script import DroidBotScript
             self.script = DroidBotScript(script_dict)
 
         self.policy = self.get_input_policy(device, app)

--- a/droidbot/input_policy.py
+++ b/droidbot/input_policy.py
@@ -2,8 +2,8 @@ import logging
 import random
 from abc import abstractmethod
 
-from input_event import KeyEvent, IntentEvent, TouchEvent, ManualEvent
-from utg import UTG
+from .input_event import KeyEvent, IntentEvent, TouchEvent, ManualEvent
+from .utg import UTG
 
 # Max number of restarts
 MAX_NUM_RESTARTS = 5

--- a/droidbot/input_policy.py
+++ b/droidbot/input_policy.py
@@ -2,8 +2,8 @@ import logging
 import random
 from abc import abstractmethod
 
-from .input_event import KeyEvent, IntentEvent, TouchEvent, ManualEvent
-from .utg import UTG
+from droidbot.input_event import KeyEvent, IntentEvent, TouchEvent, ManualEvent
+from droidbot.utg import UTG
 
 # Max number of restarts
 MAX_NUM_RESTARTS = 5
@@ -66,7 +66,7 @@ class InputPolicy(object):
                 self.logger.warning("stop sending events: %s" % e)
                 break
             # except RuntimeError as e:
-            #     self.logger.warning(e.message)
+            #     self.logger.warning(e)
             #     break
             except Exception as e:
                 self.logger.warning("exception during sending events: %s" % e)

--- a/droidbot/input_script.py
+++ b/droidbot/input_script.py
@@ -4,9 +4,9 @@
 import logging
 import re
 
-from input_event import InputEvent
-from droidbot import DroidBotException
-from utils import safe_re_match
+from .input_event import InputEvent
+from .droidbot import DroidBotException
+from .utils import safe_re_match
 
 VIEW_ID = '<view_id>'
 STATE_ID = '<state_id>'

--- a/droidbot/input_script.py
+++ b/droidbot/input_script.py
@@ -1,12 +1,13 @@
 # DroidBotScript
 # This file contains the definition of DroidBotScript
 # DroidBotScript is a domain-specific language, which defines how DroidBot interacts with target app
+
 import logging
 import re
 
-from .input_event import InputEvent
-from .droidbot import DroidBotException
-from .utils import safe_re_match
+from droidbot.droidbot import DroidBotException
+from droidbot.input_event import InputEvent
+from droidbot.utils import safe_re_match
 
 VIEW_ID = '<view_id>'
 STATE_ID = '<state_id>'
@@ -142,7 +143,7 @@ class DroidBotScript(object):
 
     @staticmethod
     def check_grammar_type(value, grammar, tag):
-        if isinstance(value, unicode) and isinstance(grammar, str):
+        if isinstance(value, str) and isinstance(grammar, str):
             return
         if not isinstance(value, type(grammar)):
             msg = '%s: type should be %s, %s given' % (tag, type(grammar), type(value))

--- a/droidbot/start.py
+++ b/droidbot/start.py
@@ -85,10 +85,10 @@ def main():
     opts = parse_args()
     import os
     if not os.path.exists(opts.apk_path):
-        print "APK does not exist."
+        print("APK does not exist.")
         return
     if not opts.output_dir and opts.cv_mode:
-        print "To run in CV mode, you need to specify an output dir (using -o option)."
+        print("To run in CV mode, you need to specify an output dir (using -o option).")
 
     droidbot = DroidBot(app_path=opts.apk_path,
                         device_serial=opts.device_serial,

--- a/droidbot/start.py
+++ b/droidbot/start.py
@@ -1,11 +1,12 @@
 # helper file of droidbot
 # it parses command arguments and send the options to droidbot
+
 import argparse
 
-from . import env_manager
-from . import input_manager
-from . import input_policy
-from .droidbot import DroidBot
+from droidbot import env_manager
+from droidbot import input_manager
+from droidbot import input_policy
+from droidbot.droidbot import DroidBot
 
 
 def parse_args():

--- a/droidbot/start.py
+++ b/droidbot/start.py
@@ -1,10 +1,11 @@
 # helper file of droidbot
 # it parses command arguments and send the options to droidbot
 import argparse
-import input_manager
-import input_policy
-import env_manager
-from droidbot import DroidBot
+
+from . import env_manager
+from . import input_manager
+from . import input_policy
+from .droidbot import DroidBot
 
 
 def parse_args():

--- a/droidbot/utg.py
+++ b/droidbot/utg.py
@@ -1,11 +1,12 @@
-import logging
+import datetime
 import json
+import logging
 import os
 import random
-import utils
-import datetime
 
 import networkx as nx
+
+from . import utils
 
 
 class UTG(object):

--- a/droidbot/utg.py
+++ b/droidbot/utg.py
@@ -6,7 +6,7 @@ import random
 
 import networkx as nx
 
-from . import utils
+from droidbot import utils
 
 
 class UTG(object):

--- a/droidbot/utils.py
+++ b/droidbot/utils.py
@@ -37,7 +37,7 @@ def get_available_devices():
     :return: list of str, each str is a device serial number
     """
     import subprocess
-    lines = subprocess.check_output(["adb", "devices"]).splitlines()
+    lines = subprocess.check_output(["adb", "devices"]).decode().splitlines()
     devices = []
     for line in lines:
         segs = line.strip().split()

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
 
         # Specify the Python versions you support here. In particular, ensure
         # that you indicate whether you support Python 2, Python 3 or both.
-        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3.5',
     ],
     entry_points={
         'console_scripts': [
@@ -41,7 +41,7 @@ setup(
         ],
     },
     package_data={
-        'droidbot': map(lambda x: os.path.relpath(x, 'droidbot'), findall('droidbot/resources/'))
+        'droidbot': list(map(lambda x: os.path.relpath(x, 'droidbot'), findall('droidbot/resources/')))
     },
     # androidviewclient doesnot support pip install, thus you should install it with easy_install
     install_requires=['androguard', 'networkx', 'Pillow'],

--- a/setup.py
+++ b/setup.py
@@ -37,12 +37,14 @@ setup(
     ],
     entry_points={
         'console_scripts': [
-            'droidbot=droidbot:start',
+            'droidbot=droidbot.start:main',
         ],
     },
     package_data={
         'droidbot': list(map(lambda x: os.path.relpath(x, 'droidbot'), findall('droidbot/resources/')))
     },
     # androidviewclient doesnot support pip install, thus you should install it with easy_install
-    install_requires=['androguard', 'networkx', 'Pillow'],
+    install_requires=['androguard==3.1.0', 'networkx', 'Pillow'],
+    # Install with --process-dependency-links flag
+    dependency_links=['https://github.com/androguard/androguard/archive/v3.1.0-pre.2.tar.gz#egg=androguard-3.1.0']
 )


### PR DESCRIPTION
This PR makes DroidBot compatible with Python3. The main changes:
- update to the last version of [androguard](https://github.com/androguard/androguard) (which has to be installed directly from GitHub as the version installed with `pip` seems not working in Python3, that's why you now need to install DroidBot using the `--process-dependency-links` flag)
- update `print` statements and some checks regarding strings
- update imports

This is still a work in progress, as I wold like to add more:
- change all `print` statements into `logger.something`
- use `.format(...)` instead of `%` in strings