### PR TITLE
Fixed UnicodeEncodeError 'charmap' codec can't encode character error

### DIFF
--- a/droidbot/adapter/logcat.py
+++ b/droidbot/adapter/logcat.py
@@ -48,7 +48,7 @@ class Logcat(Adapter):
 
         f = None
         if self.out_file is not None:
-            f = open(self.out_file, 'w')
+            f = open(self.out_file, 'w', encoding='utf-8')
 
         while self.connected:
             if self.process is None:


### PR DESCRIPTION
Fixed the below exception( Tested in python 3 environment windows)

Exception in thread Thread-5:
Traceback (most recent call last):
  File "...lib\threading.py", line 917, in _bootstrap_inner
    self.run()
  File "...lib\threading.py", line 865, in run
    self._target(*self._args, **self._kwargs)
  File "...droidbot\adapter\logcat.py", line 61, in handle_output
    f.write(line)
  File "...lib\encodings\cp1252.py", line 19, in encode
    return codecs.charmap_encode(input,self.errors,encoding_table)[0]
UnicodeEncodeError: 'charmap' codec can't encode character '\uff1a' in position 53: character maps to <undefined>