### PR TITLE
Fix incorrect main activity for certain apps

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,5 +41,5 @@ setup(
         'droidbot': [os.path.relpath(x, 'droidbot') for x in findall('droidbot/resources/')]
     },
     # androidviewclient doesnot support pip install, thus you should install it with easy_install
-    install_requires=['androguard', 'networkx', 'Pillow'],
+    install_requires=['androguard>=3.4.0a1', 'networkx', 'Pillow'],
 )


### PR DESCRIPTION
Androguard 3.3.5 introduces a bug that causes activities to incorrectly return two dots when the `android:name` attribute of the `activity` element in the Android manifest contains a shorthand name (e.g. `.App` instead of `org.mozilla.firefox.App`).
This leads to the following error message when attempting to start the activity:
```
Error: Activity class {org.mozilla.firefox/org.mozilla.firefox..App} does not exist.
```

The issue has been fixed upstream by androguard/androguard@b184771eab85f73199355f287059c557c20da2d1
The latest release that includes this fix is version 3.4.0a1 which is marked as a pre-release.
This PR updates the Androguard dependency to include the fix.