### PR TITLE
Shell-escape arguments passed to adb shell

### DIFF
--- a/droidbot/adapter/adb.py
+++ b/droidbot/adapter/adb.py
@@ -4,6 +4,10 @@ import logging
 import re
 from .adapter import Adapter
 import time
+try:
+    from shlex import quote # Python 3
+except ImportError:
+    from pipes import quote # Python 2
 
 
 class ADBException(Exception):
@@ -81,7 +85,7 @@ class ADB(Adapter):
             self.logger.warning(msg)
             raise ADBException(msg)
 
-        shell_extra_args = ['shell'] + extra_args
+        shell_extra_args = ['shell'] + [ quote(arg) for arg in extra_args ]
         return self.run_cmd(shell_extra_args)
 
     def check_connectivity(self):


### PR DESCRIPTION
Activity names containing the `$` character are not escaped, causing the shell to evaluate some parts of the argument string.
When providing an APK file with main activity such as `com.discord.app.AppActivity$Main`, an incorrect start intent for activity `com.discord.app.AppActivity` is made.

This change escapes arguments passed to `device.adb.shell()` and is compatible with Python 2 and Python 3.