### PR TITLE
Fix Import Error for Androguard >=4 and Update setup.py Entry Points due to the possible error

### DIFF
--- a/droidbot/app.py
+++ b/droidbot/app.py
@@ -25,7 +25,10 @@ class App(object):
             if not os.path.isdir(output_dir):
                 os.makedirs(output_dir)
 
-        from androguard.core.bytecodes.apk import APK
+        try:
+            from androguard.core.bytecodes.apk import APK
+        except ImportError:
+            from androguard.core.apk import APK
         self.apk = APK(self.app_path)
         self.package_name = self.apk.get_package()
         self.app_name = self.apk.get_app_name()

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
     ],
     entry_points={
         'console_scripts': [
-            'droidbot=start:main',
+            'droidbot=droidbot.start:main',
         ],
     },
     package_data={


### PR DESCRIPTION
Nowadays, the latest Androguard version is >= 4 and it has made some API changes. But droidbot didn't set the fixed version of Androguard. So when users install the latest Androguard, they may get some import error.

Changes:

* Fix Import Error:
The import statement for the APK class has been updated to ensure compatibility with androguard version 4 and above. The new code attempts to import from two possible locations, handling the potential ImportError gracefully.


* Update setup.py Entry Points:
The entry_points in the setup.py file have been modified to correctly reference the droidbot.start:main function. This ensures that the droidbot command works as expected when installed. This change will fix https://github.com/honeynet/droidbot/issues/157