### PR TITLE
fix bug: DeviceState.get_all_children doesn't return all the children

### DIFF
--- a/droidbot/device_state.py
+++ b/droidbot/device_state.py
@@ -386,7 +386,7 @@ class DeviceState(object):
         children = set(children)
         for child in children:
             children_of_child = self.get_all_children(self.views[child])
-            children.union(children_of_child)
+            children = children.union(children_of_child)
         return children
 
     def get_app_activity_depth(self, app):


### PR DESCRIPTION
```cmd
>>> a = set([1, 2, 3])
>>> b = set([2, 3, 4])
>>> a.union(b)
{1, 2, 3, 4}
>>> a
{1, 2, 3}
>>> a = a.union(b)
>>> a
{1, 2, 3, 4}
```
A set won't be update after set.union(set) called.