### PR TITLE
Avoid repeated navigation attempts after UI stagnation

### DIFF
--- a/droidbot/adapter/droidbot.py
+++ b/droidbot/adapter/droidbot.py
@@ -2,6 +2,7 @@ import logging
 import subprocess
 
 from .adapter import Adapter
+from ..input_policy import DEFAULT_NAVIGATION_STAGNATION_LIMIT
 
 
 class DroidBotConnException(Exception):
@@ -45,7 +46,8 @@ class DroidBotConn(Adapter):
                  master=None,
                  humanoid=None,
                  ignore_ad=False,
-                 replay_output=None):
+                 replay_output=None,
+                 navigation_stagnation_limit=DEFAULT_NAVIGATION_STAGNATION_LIMIT):
         """
         initiate a DroidBot connection
         :return:
@@ -77,6 +79,7 @@ class DroidBotConn(Adapter):
         self.humanoid = humanoid
         self.ignore_ad = ignore_ad
         self.replay_output = replay_output
+        self.navigation_stagnation_limit = navigation_stagnation_limit
 
         self.connected = False
         self.droidbot_p = False
@@ -88,6 +91,7 @@ class DroidBotConn(Adapter):
                         "-a", self.app_path,
                         "-interval", str(self.event_interval),
                         "-count", str(self.event_count),
+                        "--nav-stagnation-limit", str(self.navigation_stagnation_limit),
                         "-policy", self.policy_name,
                         "-grant_perm", "-keep_env",
                         "-o", "%s_%d" %

--- a/droidbot/droidbot.py
+++ b/droidbot/droidbot.py
@@ -12,7 +12,7 @@ from threading import Timer
 from .device import Device
 from .app import App
 from .env_manager import AppEnvManager
-from .input_manager import InputManager
+from .input_manager import InputManager, DEFAULT_NAVIGATION_STAGNATION_LIMIT
 
 
 class DroidBot(object):
@@ -44,7 +44,8 @@ class DroidBot(object):
                  master=None,
                  humanoid=None,
                  ignore_ad=False,
-                 replay_output=None):
+                 replay_output=None,
+                 navigation_stagnation_limit=DEFAULT_NAVIGATION_STAGNATION_LIMIT):
         """
         initiate droidbot with configurations
         :return:
@@ -109,7 +110,8 @@ class DroidBot(object):
                 script_path=script_path,
                 profiling_method=profiling_method,
                 master=master,
-                replay_output=replay_output)
+                replay_output=replay_output,
+                navigation_stagnation_limit=navigation_stagnation_limit)
         except Exception:
             import traceback
             traceback.print_exc()

--- a/droidbot/droidmaster.py
+++ b/droidbot/droidmaster.py
@@ -20,6 +20,7 @@ else:
 
 from .device import Device
 from .app import App
+from .input_policy import DEFAULT_NAVIGATION_STAGNATION_LIMIT
 
 from .adapter.droidbot import DroidBotConn
 from .adapter.qemu import QEMUConn
@@ -64,7 +65,8 @@ class DroidMaster(object):
                  qemu_no_graphic=False,
                  humanoid=None,
                  ignore_ad=False,
-                 replay_output=None):
+                 replay_output=None,
+                 navigation_stagnation_limit=DEFAULT_NAVIGATION_STAGNATION_LIMIT):
         """
         initiate droidmaster, and
         initiate droidbot's with configurations
@@ -99,6 +101,7 @@ class DroidMaster(object):
         self.humanoid = humanoid
         self.ignore_ad = ignore_ad
         self.replay_output = replay_output
+        self.navigation_stagnation_limit = navigation_stagnation_limit
 
         # 2. Initiate Device Pool
         self.domain = "localhost"
@@ -195,7 +198,8 @@ class DroidMaster(object):
                                           master="http://%s:%d/" % (self.domain, self.rpc_port),
                                           humanoid=self.humanoid,
                                           ignore_ad=self.ignore_ad,
-                                          replay_output=self.replay_output)
+                                          replay_output=self.replay_output,
+                                          navigation_stagnation_limit=self.navigation_stagnation_limit)
         device["droidbot"].set_up()
         self.logger.info("Worker: DOMAIN[%s], ADB[%s], QEMU[%d], ID[%d]" %
                          (device["domain"], device["adb_port"],

--- a/droidbot/input_manager.py
+++ b/droidbot/input_manager.py
@@ -7,6 +7,7 @@ from .input_event import EventLog
 from .input_policy import UtgBasedInputPolicy, UtgNaiveSearchPolicy, UtgGreedySearchPolicy, \
                          UtgReplayPolicy, \
                          ManualPolicy, \
+                         DEFAULT_NAVIGATION_STAGNATION_LIMIT, \
                          POLICY_NAIVE_DFS, POLICY_GREEDY_DFS, \
                          POLICY_NAIVE_BFS, POLICY_GREEDY_BFS, \
                          POLICY_REPLAY, POLICY_MEMORY_GUIDED, POLICY_LLM_GUIDED, \
@@ -30,7 +31,8 @@ class InputManager(object):
     def __init__(self, device, app, policy_name, random_input,
                  event_count, event_interval,
                  script_path=None, profiling_method=None, master=None,
-                 replay_output=None):
+                 replay_output=None,
+                 navigation_stagnation_limit=DEFAULT_NAVIGATION_STAGNATION_LIMIT):
         """
         manage input event sent to the target device
         :param device: instance of Device
@@ -51,6 +53,7 @@ class InputManager(object):
         self.event_count = event_count
         self.event_interval = event_interval
         self.replay_output = replay_output
+        self.navigation_stagnation_limit = navigation_stagnation_limit
 
         self.monkey = None
 
@@ -71,7 +74,13 @@ class InputManager(object):
         elif self.policy_name in [POLICY_NAIVE_DFS, POLICY_NAIVE_BFS]:
             input_policy = UtgNaiveSearchPolicy(device, app, self.random_input, self.policy_name)
         elif self.policy_name in [POLICY_GREEDY_DFS, POLICY_GREEDY_BFS]:
-            input_policy = UtgGreedySearchPolicy(device, app, self.random_input, self.policy_name)
+            input_policy = UtgGreedySearchPolicy(
+                device,
+                app,
+                self.random_input,
+                self.policy_name,
+                navigation_stagnation_limit=self.navigation_stagnation_limit,
+            )
         elif self.policy_name == POLICY_MEMORY_GUIDED:
             from .input_policy2 import MemoryGuidedPolicy
             input_policy = MemoryGuidedPolicy(device, app, self.random_input)

--- a/droidbot/input_policy.py
+++ b/droidbot/input_policy.py
@@ -14,6 +14,8 @@ MAX_NUM_STEPS_OUTSIDE = 5
 MAX_NUM_STEPS_OUTSIDE_KILL = 10
 # Max number of replay tries
 MAX_REPLY_TRIES = 5
+# Number of times one unchanged navigation step may be attempted.
+DEFAULT_NAVIGATION_STAGNATION_LIMIT = 8
 
 # Some input event flags
 EVENT_FLAG_STARTED = "+started"
@@ -38,6 +40,28 @@ POLICY_LLM_GUIDED = "llm_guided"  # implemented in input_policy3
 
 class InputInterruptedException(Exception):
     pass
+
+
+class NavigationStagnationTracker(object):
+    """Count repeated navigation attempts for one active target."""
+
+    def __init__(self, limit=DEFAULT_NAVIGATION_STAGNATION_LIMIT):
+        if limit <= 0:
+            raise ValueError("Navigation stagnation limit must be positive.")
+        self.limit = limit
+        self.attempt_counts = {}
+
+    def reset(self):
+        """Forget attempts after real progress or a target change."""
+        self.attempt_counts.clear()
+
+    def is_stale(self, signature):
+        """Return True after ``limit`` prior attempts of this exact step."""
+        attempt_count = self.attempt_counts.get(signature, 0)
+        if attempt_count >= self.limit:
+            return True
+        self.attempt_counts[signature] = attempt_count + 1
+        return False
 
 
 class InputPolicy(object):
@@ -353,7 +377,14 @@ class UtgGreedySearchPolicy(UtgBasedInputPolicy):
     DFS/BFS (according to search_method) strategy to explore UFG (new)
     """
 
-    def __init__(self, device, app, random_input, search_method):
+    def __init__(
+        self,
+        device,
+        app,
+        random_input,
+        search_method,
+        navigation_stagnation_limit=DEFAULT_NAVIGATION_STAGNATION_LIMIT,
+    ):
         super(UtgGreedySearchPolicy, self).__init__(device, app, random_input)
         self.logger = logging.getLogger(self.__class__.__name__)
         self.search_method = search_method
@@ -368,6 +399,9 @@ class UtgGreedySearchPolicy(UtgBasedInputPolicy):
         self.__event_trace = ""
         self.__missed_states = set()
         self.__random_explore = False
+        self.__navigation_stagnation = NavigationStagnationTracker(
+            navigation_stagnation_limit
+        )
 
     def generate_event_based_on_utg(self):
         """
@@ -452,13 +486,42 @@ class UtgGreedySearchPolicy(UtgBasedInputPolicy):
                 self.__event_trace += EVENT_FLAG_EXPLORE
                 return input_event
 
-        target_state = self.__get_nav_target(current_state)
-        if target_state:
+        # Search through candidate targets.
+        # Skip stale or unreachable targets and try another target in the same
+        # cycle instead of falling through to random exploration or app restart.
+        while True:
+            target_state = self.__get_nav_target(current_state)
+            if not target_state:
+                break
             navigation_steps = self.utg.get_navigation_steps(from_state=current_state, to_state=target_state)
-            if navigation_steps and len(navigation_steps) > 0:
-                self.logger.info("Navigating to %s, %d steps left." % (target_state.state_str, len(navigation_steps)))
-                self.__event_trace += EVENT_FLAG_NAVIGATE
-                return navigation_steps[0][1]
+            if not navigation_steps:
+                self.__missed_states.add(target_state.state_str)
+                self.__nav_target = None
+                self.__nav_num_steps = -1
+                self.__navigation_stagnation.reset()
+                continue
+            next_event = navigation_steps[0][1]
+            signature = (
+                current_state.state_str,
+                target_state.state_str,
+                next_event.get_event_str(current_state),
+                len(navigation_steps),
+            )
+            if self.__navigation_stagnation.is_stale(signature):
+                self.logger.warning(
+                    "Navigation to %s stagnated after %d identical attempts; "
+                    "marking the target as missed.",
+                    target_state.state_str,
+                    self.__navigation_stagnation.limit,
+                )
+                self.__missed_states.add(target_state.state_str)
+                self.__nav_target = None
+                self.__nav_num_steps = -1
+                self.__navigation_stagnation.reset()
+                continue
+            self.logger.info("Navigating to %s, %d steps left." % (target_state.state_str, len(navigation_steps)))
+            self.__event_trace += EVENT_FLAG_NAVIGATE
+            return next_event
 
         if self.__random_explore:
             self.logger.info("Trying random event.")
@@ -506,11 +569,14 @@ class UtgGreedySearchPolicy(UtgBasedInputPolicy):
             navigation_steps = self.utg.get_navigation_steps(from_state=current_state, to_state=self.__nav_target)
             if navigation_steps and 0 < len(navigation_steps) <= self.__nav_num_steps:
                 # If last navigation was successful, use current nav target
+                if len(navigation_steps) < self.__nav_num_steps:
+                    self.__navigation_stagnation.reset()
                 self.__nav_num_steps = len(navigation_steps)
                 return self.__nav_target
             else:
                 # If last navigation was failed, add nav target to missing states
                 self.__missed_states.add(self.__nav_target.state_str)
+                self.__navigation_stagnation.reset()
 
         reachable_states = self.utg.get_reachable_states(current_state)
         if self.random_input:
@@ -530,10 +596,12 @@ class UtgGreedySearchPolicy(UtgBasedInputPolicy):
             navigation_steps = self.utg.get_navigation_steps(from_state=current_state, to_state=self.__nav_target)
             if len(navigation_steps) > 0:
                 self.__nav_num_steps = len(navigation_steps)
+                self.__navigation_stagnation.reset()
                 return state
 
         self.__nav_target = None
         self.__nav_num_steps = -1
+        self.__navigation_stagnation.reset()
         return None
 
 class UtgReplayPolicy(InputPolicy):

--- a/droidbot/start.py
+++ b/droidbot/start.py
@@ -8,6 +8,14 @@ from .droidbot import DroidBot
 from .droidmaster import DroidMaster
 
 
+def positive_int(value):
+    """Parse a strictly positive command-line integer."""
+    parsed = int(value)
+    if parsed <= 0:
+        raise argparse.ArgumentTypeError("must be a positive integer")
+    return parsed
+
+
 def parse_args():
     """
     parse command line input
@@ -65,6 +73,18 @@ def parse_args():
                         help="Interval in seconds between each two events. Default: %d" % input_manager.DEFAULT_EVENT_INTERVAL)
     parser.add_argument("-timeout", action="store", dest="timeout", default=input_manager.DEFAULT_TIMEOUT, type=int,
                         help="Timeout in seconds, -1 means unlimited. Default: %d" % input_manager.DEFAULT_TIMEOUT)
+    parser.add_argument(
+        "--nav-stagnation-limit",
+        action="store",
+        dest="navigation_stagnation_limit",
+        default=input_manager.DEFAULT_NAVIGATION_STAGNATION_LIMIT,
+        type=positive_int,
+        help=(
+            "Number of identical navigation-step attempts before choosing "
+            "another target. Default: %d"
+            % input_manager.DEFAULT_NAVIGATION_STAGNATION_LIMIT
+        ),
+    )
     parser.add_argument("-cv", action="store_true", dest="cv_mode",
                         help="Use OpenCV (instead of UIAutomator) to identify UI components. CV mode requires opencv-python installed.")
     parser.add_argument("-debug", action="store_true", dest="debug_mode",
@@ -139,7 +159,8 @@ def main():
             qemu_no_graphic=opts.qemu_no_graphic,
             humanoid=opts.humanoid,
             ignore_ad=opts.ignore_ad,
-            replay_output=opts.replay_output)
+            replay_output=opts.replay_output,
+            navigation_stagnation_limit=opts.navigation_stagnation_limit)
         droidmaster.start()
     else:
         droidbot = DroidBot(
@@ -165,7 +186,8 @@ def main():
             master=opts.master,
             humanoid=opts.humanoid,
             ignore_ad=opts.ignore_ad,
-            replay_output=opts.replay_output)
+            replay_output=opts.replay_output,
+            navigation_stagnation_limit=opts.navigation_stagnation_limit)
         droidbot.start()
     return
 

--- a/tests/test_navigation_stagnation.py
+++ b/tests/test_navigation_stagnation.py
@@ -1,0 +1,149 @@
+import argparse
+import unittest
+
+from droidbot.input_policy import (
+    NavigationStagnationTracker,
+    POLICY_GREEDY_DFS,
+    UtgGreedySearchPolicy,
+)
+from droidbot.start import positive_int
+
+
+class FakeDevice(object):
+    humanoid = None
+
+
+class FakeApp(object):
+    pass
+
+
+class FakeState(object):
+    def __init__(self, state_str):
+        self.state_str = state_str
+
+    def get_app_activity_depth(self, app):
+        return 0
+
+    def get_possible_input(self):
+        return []
+
+
+class FakeEvent(object):
+    def __init__(self, event_str):
+        self.event_str = event_str
+
+    def get_event_str(self, state):
+        return self.event_str
+
+
+class FakeUtg(object):
+    def __init__(self, targets, routes):
+        self.targets = targets
+        self.routes = routes
+
+    def is_event_explored(self, event, state):
+        return True
+
+    def get_reachable_states(self, current_state):
+        return self.targets
+
+    def is_state_explored(self, state):
+        return False
+
+    def get_navigation_steps(self, from_state, to_state):
+        event, step_count = self.routes[to_state.state_str]
+        return [(None, event)] * step_count
+
+
+class NavigationStagnationTrackerTest(unittest.TestCase):
+    def test_marks_signature_stale_after_configured_attempts(self):
+        tracker = NavigationStagnationTracker(limit=8)
+        signature = ("state-a", "target", "touch-button", 4)
+
+        for _ in range(8):
+            self.assertFalse(tracker.is_stale(signature))
+
+        self.assertTrue(tracker.is_stale(signature))
+
+    def test_counts_interleaved_signatures_independently(self):
+        tracker = NavigationStagnationTracker(limit=2)
+        signature_a = ("state-a", "target", "touch-button", 4)
+        signature_b = ("state-b", "target", "BACK", 4)
+
+        self.assertFalse(tracker.is_stale(signature_a))
+        self.assertFalse(tracker.is_stale(signature_b))
+        self.assertFalse(tracker.is_stale(signature_a))
+        self.assertFalse(tracker.is_stale(signature_b))
+        self.assertTrue(tracker.is_stale(signature_a))
+        self.assertTrue(tracker.is_stale(signature_b))
+
+    def test_reset_forgets_attempts_after_progress(self):
+        tracker = NavigationStagnationTracker(limit=1)
+        signature = ("state-a", "target", "touch-button", 4)
+
+        self.assertFalse(tracker.is_stale(signature))
+        tracker.reset()
+
+        self.assertFalse(tracker.is_stale(signature))
+
+    def test_rejects_non_positive_limit(self):
+        with self.assertRaisesRegex(ValueError, "must be positive"):
+            NavigationStagnationTracker(limit=0)
+
+    def test_cli_limit_must_be_positive(self):
+        self.assertEqual(positive_int("8"), 8)
+        with self.assertRaisesRegex(
+            argparse.ArgumentTypeError, "must be a positive integer"
+        ):
+            positive_int("0")
+
+    def test_policy_chooses_another_target_after_stagnation(self):
+        current_state = FakeState("current")
+        stale_target = FakeState("stale-target")
+        alternate_target = FakeState("alternate-target")
+        stale_event = FakeEvent("touch-button")
+        alternate_event = FakeEvent("touch-link")
+        policy = UtgGreedySearchPolicy(
+            FakeDevice(),
+            FakeApp(),
+            random_input=False,
+            search_method=POLICY_GREEDY_DFS,
+            navigation_stagnation_limit=2,
+        )
+        policy.utg = FakeUtg(
+            [stale_target, alternate_target],
+            {
+                stale_target.state_str: (stale_event, 4),
+                alternate_target.state_str: (alternate_event, 3),
+            },
+        )
+        policy.current_state = current_state
+
+        self.assertIs(policy.generate_event_based_on_utg(), stale_event)
+        self.assertIs(policy.generate_event_based_on_utg(), stale_event)
+        self.assertIs(policy.generate_event_based_on_utg(), alternate_event)
+
+    def test_policy_resets_attempts_when_route_gets_shorter(self):
+        current_state = FakeState("current")
+        target = FakeState("target")
+        event = FakeEvent("touch-button")
+        policy = UtgGreedySearchPolicy(
+            FakeDevice(),
+            FakeApp(),
+            random_input=False,
+            search_method=POLICY_GREEDY_DFS,
+            navigation_stagnation_limit=2,
+        )
+        fake_utg = FakeUtg([target], {target.state_str: (event, 4)})
+        policy.utg = fake_utg
+        policy.current_state = current_state
+
+        self.assertIs(policy.generate_event_based_on_utg(), event)
+        self.assertIs(policy.generate_event_based_on_utg(), event)
+        fake_utg.routes[target.state_str] = (event, 3)
+
+        self.assertIs(policy.generate_event_based_on_utg(), event)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- track repeated navigation attempts that leave DroidBot on the same UI state
- mark a target as stale after a configurable number of identical attempts so exploration can choose another target
- reset attempt history when navigation makes progress or the route becomes shorter
- expose `--nav-stagnation-limit` and propagate it through worker, master, and input-manager configuration

## Motivation: Wikipedia navigation livelock

During Wikipedia exploration, the greedy policy could repeatedly select the
same first navigation step when the current state, target, event, and remaining
route length were all unchanged. The target still appeared reachable in the
UTG, so the policy kept retrying it instead of moving to another candidate.

A shortened excerpt from the saved Wikipedia run shows the unchanged state
immediately after a touch:

```text
INFO:UtgGreedySearchPolicy:Current state: d6edb7d2f07210f69fa8df65a039ed7f
INFO:UtgGreedySearchPolicy:Trying an unexplored event.
Action: TouchEvent(state=d6edb7d2f07210f69fa8df65a039ed7f,
                   view=7d70678898734cdbc0424553876965fe(DefaultIcon/View-))
INFO:UtgGreedySearchPolicy:Current state: d6edb7d2f07210f69fa8df65a039ed7f
```

The saved smoke log contains the no-progress symptom rather than the entire
later livelock. The regression test reproduces the repeated navigation
signature directly. After the configured limit, the policy emits:

```text
WARNING:UtgGreedySearchPolicy:Navigation to stale-target stagnated after 2 identical attempts; marking the target as missed.
```

It then selects the next reachable target during the same policy cycle.

## Testing

- `python -m unittest discover -s tests -v` — 7 tests passed
- `python -m compileall -q droidbot`
- `git diff --check origin/master..HEAD`

